### PR TITLE
[FIX] Move overlaying points logic to the correct place and other cleanup

### DIFF
--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import gc
 import io
-import re
 import time
 from pathlib import Path
 from typing import Annotated, Any
@@ -152,30 +151,6 @@ class AudioVLM:
                 self.model_store["Loaded"] = True
             case _:
                 pass
-
-    @classmethod
-    def parse_points(cls, points_str: str):
-        # Regex to extract each <points> tag with multiple x and y pairs
-        point_tags = re.findall(r"<points (.*?)>(.*?)</points>", points_str)
-        if len(point_tags) == 0:
-            point_tags = re.findall(r"<point (.*?)>(.*?)</point>", points_str)
-        parsed_points = []
-        if len(point_tags) == 0:
-            return None
-
-        for attributes, label in point_tags:
-            coordinates = re.findall(r'x\d+="(.*?)" y\d+="(.*?)"', attributes)
-            if not coordinates:
-                single_coordinate = re.findall(r'x="(.*?)" y="(.*?)"', attributes)
-                if single_coordinate:
-                    coordinates = [single_coordinate[0]]
-            parsed_points.append(
-                {
-                    "label": label,
-                    "coordinates": [(float(x), float(y)) for x, y in coordinates],
-                }
-            )
-        return parsed_points
 
     _default_system_prompt = "You are an unbiased, helpful assistant."
 

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -243,9 +243,6 @@ class AudioVLM:
             generated_tokens, skip_special_tokens=True
         )
 
-        points_data = self.parse_points(generated_text)
-        if points_data:
-            self.overlay_points(points_data)
         time.sleep(0.1)
         return generated_text
 

--- a/audiovlm_demo/main.py
+++ b/audiovlm_demo/main.py
@@ -9,7 +9,7 @@ def main():
     )
     A = AudioVLM(config=config)
     UI = AudioVLMPanel(engine=A)  # noqa: F841
-    return UI.servable()
+    return UI
 
 
 main()

--- a/audiovlm_demo/ui/panel.py
+++ b/audiovlm_demo/ui/panel.py
@@ -227,6 +227,9 @@ class AudioVLMPanel:
                 image=image,
                 chat_history=self.build_chat_history(instance),
             )
+            points_data = self.parse_points(generated_text)
+            if points_data:
+                self.overlay_points(points_data)
             return generated_text
         elif self.toggle_group.value == "Aria":
             image_or_error_message = AudioVLMPanel.validate_image_input(

--- a/environment.yaml
+++ b/environment.yaml
@@ -19,7 +19,7 @@ dependencies:
   - safetensors
   - tokenizers
   - torchtriton
-  - transformers
+  - transformers=4.46.2
   - pillow
   - einops
   - bokeh-root-cmd>=0.1.2


### PR DESCRIPTION
The overlaying points functionality for Molmo was not in the correct place and thus caused an error. This PR fixes that.

The version of `transformers` also gets pinned in this PR, c.f. #16. 