### PR TITLE
Push to Quay.io

### DIFF
--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -28,3 +28,10 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_ID }}
           password: ${{ secrets.QUAY_PW }}
+
+      - name: Compute image tag
+        id: compute-image-tag
+        run: |
+          short_sha=$(git rev-parse --short ${{ github.sha }})
+          echo "tag=quay.io/${{ secrets.QUAY_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
+          echo "short_sha=$short_sha" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -3,6 +3,7 @@ name: Build and push Docker image to Quay.io
 on:
   push:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build-and-push:

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ID }}
-          password: ${{ secrets.QUAY_PW }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Compute image tag
         id: compute-image-tag

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -7,11 +7,6 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
 
     steps:
       - name: Checkout
@@ -19,8 +14,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: network=host        
 
       - name: Login to Quay.io
         uses: docker/login-action@v3

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -45,7 +45,11 @@ jobs:
         id: compute-image-tag
         run: |
           short_sha=$(git rev-parse --short ${{ github.sha }})
-          echo "tag=quay.io/${{ secrets.QUAY_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
+          if [[ "${{ steps.should-push.outputs.push-to-quay }}" == "true" ]]; then
+            echo "tag=quay.io/${{ secrets.QUAY_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
+          else
+            echo "tag=audiovlm-demo" >> $GITHUB_OUTPUT
+          fi
           echo "short_sha=$short_sha" >> $GITHUB_OUTPUT
 
       - name: Build Docker image

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host        
+
       - name: Login to Quay.io
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -1,1 +1,5 @@
 name: Build and push Docker image to Quay.io
+
+on:
+  push:
+  workflow_dispatch:

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -2,6 +2,7 @@ name: Build and push Docker image to Quay.io
 
 on:
   push:
+    branches: ["main"]
   workflow_dispatch:
   pull_request:
 
@@ -21,7 +22,7 @@ jobs:
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           echo "branch=$branch" >> $GITHUB_OUTPUT
-          if [[ ( "${{ github.event.pull_request.merged }}" == true && "$branch" == "main" ) || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
             echo "push-to-quay=true" >> $GITHUB_OUTPUT
             echo This action is being run as the result of a pull request being merged to the main branch or via workflow dispatch. \
             The Docker image will be pushed to Quay.io.

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -15,8 +15,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Decide whether to push to Quay
+        id: should-push
+        run: |
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "branch=$branch" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event.pull_request.merged }}" == "true" && "$branch" == "main" || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+            echo "push-to-quay=true" >> $GITHUB_OUTPUT
+            echo This action is being run as the result of a pull request being merged to the main branch or via workflow dispatch. \
+            The Docker image will be pushed to Quay.io.
+          else
+            echo "push-to-quay=false" >> $GITHUB_OUTPUT
+            echo This action is being run as the result of a push. The Docker will be built for the purpose of developer feedback, but \
+            it will not be pushed to Quay.io.
+          fi
+
+          cat "$GITHUB_OUTPUT"
+
       - name: Login to Quay.io
         uses: docker/login-action@v3
+        if: steps.should-push.outputs.push-to-quay == 'true'
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ID }}
@@ -33,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ steps.should-push.outputs.push-to-quay }}
           file: Dockerfile
           tags: |
             ${{ steps.compute-image-tag.outputs.tag }}:${{ steps.compute-image-tag.outputs.short_sha }}

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -16,3 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ID }}
+          password: ${{ secrets.QUAY_PW }}

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -35,3 +35,13 @@ jobs:
           short_sha=$(git rev-parse --short ${{ github.sha }})
           echo "tag=quay.io/${{ secrets.QUAY_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
           echo "short_sha=$short_sha" >> $GITHUB_OUTPUT
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: Dockerfile
+          tags: |
+            ${{ steps.compute-image-tag.outputs.tag }}:${{ steps.compute-image-tag.outputs.short_sha }}
+            ${{ steps.compute-image-tag.outputs.tag }}:latest

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           echo "branch=$branch" >> $GITHUB_OUTPUT
-          if [[ "${{ github.event.pull_request.merged }}" == "true" && "$branch" == "main" || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          if [[ ( "${{ github.event.pull_request.merged }}" == "true" && "$branch" == "main" ) || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
             echo "push-to-quay=true" >> $GITHUB_OUTPUT
             echo This action is being run as the result of a pull request being merged to the main branch or via workflow dispatch. \
             The Docker image will be pushed to Quay.io.

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -3,3 +3,12 @@ name: Build and push Docker image to Quay.io
 on:
   push:
   workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           echo "branch=$branch" >> $GITHUB_OUTPUT
-          if [[ ( "${{ github.event.pull_request.merged }}" == 'true' && "$branch" == "main" ) || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          if [[ ( "${{ github.event.pull_request.merged }}" == true && "$branch" == "main" ) || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
             echo "push-to-quay=true" >> $GITHUB_OUTPUT
             echo This action is being run as the result of a pull request being merged to the main branch or via workflow dispatch. \
             The Docker image will be pushed to Quay.io.

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -12,3 +12,7 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -1,0 +1,1 @@
+name: Build and push Docker image to Quay.io

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           echo "branch=$branch" >> $GITHUB_OUTPUT
-          if [[ ( "${{ github.event.pull_request.merged }}" == "true" && "$branch" == "main" ) || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          if [[ ( "${{ github.event.pull_request.merged }}" == 'true' && "$branch" == "main" ) || "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
             echo "push-to-quay=true" >> $GITHUB_OUTPUT
             echo This action is being run as the result of a pull request being merged to the main branch or via workflow dispatch. \
             The Docker image will be pushed to Quay.io.


### PR DESCRIPTION
This PR builds the Docker image for this repo for every push when a pull request is open, and pushes it to Quay.io if and only if the event is a pull request merged to main or if the event is a workflow dispatch.

I have set the `QUAY_ID` and `QUAY_PW` secrets on both my fork and the upstream fork to the credentials for my personal Quay account. To start pushing to the Quansight Quay account, all that is needed is to change the secrets on the upstream fork.