### PR TITLE
Fix account id and tag

### DIFF
--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           short_sha=$(git rev-parse --short ${{ github.sha }})
           if [[ "${{ steps.should-push.outputs.push-to-quay }}" == "true" ]]; then
-            echo "tag=quay.io/${{ secrets.QUAY_ACCOUNT_OWNER_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
+            echo "tag=quay.io/${{ var.QUAY_ACCOUNT_OWNER_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
           else
             echo "tag=audiovlm-demo" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/deploy-to-quay.yml
+++ b/.github/workflows/deploy-to-quay.yml
@@ -39,7 +39,7 @@ jobs:
         if: steps.should-push.outputs.push-to-quay == 'true'
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_ID }}
+          username: ${{ secrets.QUAY_ROBOT_ACCOUNT_ID }}
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Compute image tag
@@ -47,7 +47,7 @@ jobs:
         run: |
           short_sha=$(git rev-parse --short ${{ github.sha }})
           if [[ "${{ steps.should-push.outputs.push-to-quay }}" == "true" ]]; then
-            echo "tag=quay.io/${{ secrets.QUAY_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
+            echo "tag=quay.io/${{ secrets.QUAY_ACCOUNT_OWNER_ID }}/audiovlm-demo" >> $GITHUB_OUTPUT
           else
             echo "tag=audiovlm-demo" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Using the Quay robot account ID in the Docker image tag is incorrect and invalid. The solution is to use the Quay account owner ID in the Docker image tag and the Quay robot account ID for authentication. This PR implements those fixes.