### PR TITLE
Temporarily disable unusable models until they become usable

### DIFF
--- a/audiovlm_demo/ui/panel.py
+++ b/audiovlm_demo/ui/panel.py
@@ -28,7 +28,12 @@ class AudioVLMPanel:
 
         self.toggle_group = pn.widgets.ToggleGroup(
             name="Model Select",
-            options=["Molmo-7B-D-0924", "Molmo-7B-D-0924-4bit", "Aria", "Qwen2-Audio"],
+            options=[
+                "Molmo-7B-D-0924",
+                "Molmo-7B-D-0924-4bit",
+                # "Aria",
+                # "Qwen2-Audio",
+            ],
             behavior="radio",
         )
         self.load_button = pn.widgets.Button(name="Load Model", button_type="primary")


### PR DESCRIPTION
[We are experiencing an error with Aria](https://github.com/Quansight/genai-demo-audio-vlm/issues/8), and have not tested Qwen, so I am temporarily disabling them in the UI, leaving only the models we have tested and know are working.