### PR TITLE
Call APIs for Molmo instead of storing and calling it locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:cuda12.6.3-ubuntu24.04
+FROM mambaorg/micromamba:debian12-slim
 
 WORKDIR /app
 

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -223,26 +223,6 @@ class AudioVLM:
             "Assistant",
         )
 
-        inputs = self.model_store["Processor"].process(images=[image], text=prompt_full)
-
-        inputs = {
-            k: v.to(self.model_store["Model"].device).unsqueeze(0)
-            for k, v in inputs.items()
-        }
-
-        with torch.autocast(device_type="cuda", enabled=True, dtype=torch.bfloat16):
-            output = self.model_store["Model"].generate_from_batch(
-                inputs,
-                GenerationConfig(max_new_tokens=1250, stop_strings="<|endoftext|>"),
-                tokenizer=self.model_store["Processor"].tokenizer,
-            )
-
-        generated_tokens = output[0, inputs["input_ids"].size(1) :]
-        self.model_store["History"].append(generated_tokens)
-        generated_text = self.model_store["Processor"].tokenizer.decode(
-            generated_tokens, skip_special_tokens=True
-        )
-
         time.sleep(0.1)
         return generated_text
 

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -99,8 +99,8 @@ class AudioVLM:
 
         match model_selection:
             case "Molmo-7B-D-0924":
-                if "molmo" not in self.api_keys:
-                    self.api_keys["molmo"] = os.environ.get("MOLMO_API_KEY")
+                if "runpod" not in self.api_keys:
+                    self.api_keys["runpod"] = os.environ.get("RUNPOD_API_KEY")
                 if "molmo" not in self.api_endpoint_ids:
                     self.api_endpoint_ids["molmo"] = os.environ.get("MOLMO_ENDPOINT_ID")
 
@@ -256,7 +256,7 @@ class AudioVLM:
 
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.api_keys['molmo']}",
+            "Authorization": f"Bearer {self.api_keys['runpod']}",
         }
 
         response = httpx.post(

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -225,7 +225,7 @@ class AudioVLM:
         return "".join(texts)
 
     # TODO: Add type annotations
-    def molmo_callback(self, *, image, chat_history):
+    def molmo_callback(self, *, file_name, image, chat_history):
         prompt_full = self.compile_prompt(
             chat_history,
             "User",
@@ -238,7 +238,7 @@ class AudioVLM:
         return generated_text
 
     # TODO: Add type annotations
-    def aria_callback(self, *, image, chat_history):
+    def aria_callback(self, *, file_name, image, chat_history):
         messages = self.engine.compile_prompt_gguf(
             chat_history,
             "User",
@@ -275,7 +275,7 @@ class AudioVLM:
         return result
 
     # TODO: Add type annotations
-    def qwen_callback(self, *, audio_file_content, chat_history):
+    def qwen_callback(self, *, file_name, audio_file_content, chat_history):
         messages = chat_history[-1]
         if messages["role"] == "User":
             text_input = messages["content"]

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import gc
 import io
+import os
 import time
 from pathlib import Path
 from typing import Annotated, Any
@@ -53,6 +54,7 @@ class AudioVLM:
     def __init__(self, *, config: Config, model_store: dict | None = None):
         self.config = config
         model_store_keys = {"Loaded", "History", "Model", "Processor"}
+        self.api_secrets = {}
         if model_store is not None:
             if not model_store_keys <= model_store.keys():
                 raise ValueError(
@@ -89,19 +91,19 @@ class AudioVLM:
 
         match model_selection:
             case "Molmo-7B-D-0924":
-                model_id_or_path = self.molmo_model_id
-                self.model_store["Processor"] = AutoProcessor.from_pretrained(
-                    model_id_or_path,
-                    trust_remote_code=True,
-                    torch_dtype=torch.bfloat16,
-                    device_map="auto",
-                )
-                self.model_store["Model"] = AutoModelForCausalLM.from_pretrained(
-                    model_id_or_path,
-                    trust_remote_code=True,
-                    torch_dtype=torch.bfloat16,
-                    device_map="auto",
-                )
+                # model_id_or_path = self.molmo_model_id
+                # self.model_store["Processor"] = AutoProcessor.from_pretrained(
+                #     model_id_or_path,
+                #     trust_remote_code=True,
+                #     torch_dtype=torch.bfloat16,
+                #     device_map="auto",
+                # )
+                # self.model_store["Model"] = AutoModelForCausalLM.from_pretrained(
+                #     model_id_or_path,
+                #     trust_remote_code=True,
+                #     torch_dtype=torch.bfloat16,
+                #     device_map="auto",
+                # )
                 self.model_store["Loaded"] = True
             case "Molmo-7B-D-0924-4bit":
                 model_id_or_path = self.molmo_model_id

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -54,7 +54,8 @@ class AudioVLM:
     def __init__(self, *, config: Config, model_store: dict | None = None):
         self.config = config
         model_store_keys = {"Loaded", "History", "Model", "Processor"}
-        self.api_secrets = {}
+        self.api_keys = {}
+        self.api_endpoint_ids = {}
         if model_store is not None:
             if not model_store_keys <= model_store.keys():
                 raise ValueError(
@@ -91,6 +92,11 @@ class AudioVLM:
 
         match model_selection:
             case "Molmo-7B-D-0924":
+                if "molmo" not in self.api_keys:
+                    self.api_keys["molmo"] = os.environ.get("MOLMO_API_KEY")
+                if "molmo" not in self.api_endpoint_ids:
+                    self.api_endpoint_ids["molmo"] = os.environ.get("MOLMO_ENDPOINT_ID")
+
                 # model_id_or_path = self.molmo_model_id
                 # self.model_store["Processor"] = AutoProcessor.from_pretrained(
                 #     model_id_or_path,

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import base64
 import gc
 import io
 import time
@@ -14,7 +16,6 @@ from transformers import (
     AutoModelForCausalLM,
     AutoProcessor,
     BitsAndBytesConfig,
-    GenerationConfig,
     Qwen2AudioForConditionalGeneration,
 )
 
@@ -222,6 +223,8 @@ class AudioVLM:
             "User",
             "Assistant",
         )
+
+        image = base64.b64encode(image).decode("utf8")
 
         time.sleep(0.1)
         return generated_text

--- a/audiovlm_demo/core/utils.py
+++ b/audiovlm_demo/core/utils.py
@@ -1,5 +1,18 @@
+import base64
+import mimetypes
 from pathlib import Path
 
 
 def resolve_path(path: Path | str) -> Path:
     return Path(path).expanduser().resolve()
+
+
+def encode_file_to_data_url(filename, file_contents) -> str:
+    """Converts image file to data url to display in browser."""
+    base64_encoded = base64.b64encode(file_contents)
+    filename_ = filename.lower()
+    mime_type = mimetypes.guess_type(filename_)[0]
+    if mime_type is None:
+        raise ValueError(f"Could not determine mimetype of file {filename_}")
+    data_url = f"data:{mime_type};base64,{base64_encoded.decode('utf-8')}"
+    return data_url

--- a/audiovlm_demo/ui/panel.py
+++ b/audiovlm_demo/ui/panel.py
@@ -30,7 +30,7 @@ class AudioVLMPanel:
             name="Model Select",
             options=[
                 "Molmo-7B-D-0924",
-                "Molmo-7B-D-0924-4bit",
+                # "Molmo-7B-D-0924-4bit",
                 # "Aria",
                 # "Qwen2-Audio",
             ],

--- a/audiovlm_demo/ui/panel.py
+++ b/audiovlm_demo/ui/panel.py
@@ -266,7 +266,7 @@ class AudioVLMPanel:
                 del audio_or_error_message
             response = self.engine.qwen_callback(
                 file_name=file_name,
-                audio_file_content=audio_or_error_message,
+                audio_file_content=audio_file_content,
                 chat_history=self.build_chat_history(instance),
             )
             return response

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,6 @@ services:
     restart: unless-stopped
     ports:
       - "5006:5006"
+    environment:
+      - MOLMO_ENDPOINT_ID=${MOLMO_ENDPOINT_ID}
+      - MOLMO_API_KEY=${MOLMO_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,3 @@ services:
     restart: unless-stopped
     ports:
       - "5006:5006"
-    volumes:
-      - model-data:/home/mambauser/.cache
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-
-volumes:
-  model-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       - "5006:5006"
     environment:
       - MOLMO_ENDPOINT_ID=${MOLMO_ENDPOINT_ID}
-      - MOLMO_API_KEY=${MOLMO_API_KEY}
+      - RUNPOD_API_KEY=${RUNPOD_API_KEY}

--- a/environment.yaml
+++ b/environment.yaml
@@ -29,6 +29,7 @@ dependencies:
   - pydantic>=2
   - pydantic-settings>=2
   - tomlkit
+  - httpx
   - pip:
       - bitsandbytes
       - flash-attn


### PR DESCRIPTION
Addresses #23

Adds API calls to Molmo hosted on RunPod.io instead of storing models in cache/volumes.

The remaining models will be added in a subsequent PR.