### PR TITLE
Call model APIs for remaining APIs

### DIFF
--- a/audiovlm_demo/__init__.py
+++ b/audiovlm_demo/__init__.py
@@ -1,8 +1,7 @@
 __all__ = [
     "AudioVLM",
     "AudioVLMPanel",
-    "Config",
 ]
 
-from audiovlm_demo.core.components import AudioVLM, Config
+from audiovlm_demo.core.components import AudioVLM
 from audiovlm_demo.ui.panel import AudioVLMPanel

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -103,20 +103,6 @@ class AudioVLM:
                     self.api_keys["runpod"] = os.environ.get("RUNPOD_API_KEY")
                 if "molmo" not in self.api_endpoint_ids:
                     self.api_endpoint_ids["molmo"] = os.environ.get("MOLMO_ENDPOINT_ID")
-
-                # model_id_or_path = self.molmo_model_id
-                # self.model_store["Processor"] = AutoProcessor.from_pretrained(
-                #     model_id_or_path,
-                #     trust_remote_code=True,
-                #     torch_dtype=torch.bfloat16,
-                #     device_map="auto",
-                # )
-                # self.model_store["Model"] = AutoModelForCausalLM.from_pretrained(
-                #     model_id_or_path,
-                #     trust_remote_code=True,
-                #     torch_dtype=torch.bfloat16,
-                #     device_map="auto",
-                # )
                 self.model_store["Loaded"] = True
             # case "Molmo-7B-D-0924-4bit":
             #     model_id_or_path = self.molmo_model_id

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -228,7 +228,7 @@ class AudioVLM:
         with io.BytesIO() as output:
             image.save(
                 output,
-                format=mimetypes.guess_type(file_name)[0].split("/")[-1],
+                format=image.format,
             )
             image = output.getvalue()
         image = base64.b64encode(image).decode("utf8")

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -5,16 +5,11 @@ import gc
 import io
 import os
 import time
-from pathlib import Path
-from typing import Annotated, Any
+from typing import Any
 
 import httpx
-import tomlkit
 import torch
-from pydantic import AfterValidator
-from pydantic_settings import BaseSettings
 
-from audiovlm_demo.core.utils import resolve_path
 
 
 class AudioVLM:

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -269,7 +269,7 @@ class AudioVLM:
 
     # TODO: Add type annotations
     def aria_callback(self, *, file_name, image, chat_history):
-        messages = self.engine.compile_prompt_gguf(
+        messages = self.compile_prompt_gguf(
             chat_history,
             "User",
             "Assistant",
@@ -283,7 +283,14 @@ class AudioVLM:
             image = output.getvalue()
         image = base64.b64encode(image).decode("utf8")
 
-        return result
+        data = {
+            "input": {
+                "image": image,
+                "text": messages,
+            },
+        }
+
+        return "Needs more reverb."
 
     # TODO: Add type annotations
     def qwen_callback(self, *, file_name, audio_file_content, chat_history):

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -290,6 +290,11 @@ class AudioVLM:
             },
         }
 
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_keys['runpod']}",
+        }
+
         return "Needs more reverb."
 
     # TODO: Add type annotations

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -302,10 +302,13 @@ class AudioVLM:
         messages = [{"role": "system", "content": "You are a helpful assistant."}] + [
             {
                 "role": utterance["role"].lower(),
-                "content": {
-                    "type": "text",
-                    "text": utterance["content"],
-                },
+                "content": [
+                    {"type": "audio", "audio_url": "filler.wav"},
+                    {
+                        "type": "text",
+                        "text": utterance["content"],
+                    },
+                ],
             }
             for utterance in chat_history
         ]

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -8,7 +8,6 @@ import time
 from typing import Any
 
 import httpx
-import torch
 
 
 class AudioVLM:
@@ -48,7 +47,6 @@ class AudioVLM:
             del self.model_store["Model"]
             del self.model_store["Processor"]
             gc.collect()
-            torch.cuda.empty_cache()
             self.model_store["Model"] = None
             self.model_store["Processor"] = None
             self.model_store["Loaded"] = False

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -97,10 +97,11 @@ class AudioVLM:
         if self.model_store["Model"]:
             self.model_cleanup()
 
+        if "runpod" not in self.api_keys:
+            self.api_keys["runpod"] = os.environ.get("RUNPOD_API_KEY")
+
         match model_selection:
             case "Molmo-7B-D-0924":
-                if "runpod" not in self.api_keys:
-                    self.api_keys["runpod"] = os.environ.get("RUNPOD_API_KEY")
                 if "molmo" not in self.api_endpoint_ids:
                     self.api_endpoint_ids["molmo"] = os.environ.get("MOLMO_ENDPOINT_ID")
                 self.model_store["Loaded"] = True
@@ -129,16 +130,8 @@ class AudioVLM:
             #     )
             #     self.model_store["Loaded"] = True
             case "Aria":
-                model_id_or_path = self.aria_model_id
-                self.model_store["Processor"] = AutoProcessor.from_pretrained(
-                    model_id_or_path, trust_remote_code=True
-                )
-                self.model_store["Model"] = AutoModelForCausalLM.from_pretrained(
-                    model_id_or_path,
-                    device_map="auto",
-                    torch_dtype=torch.bfloat16,
-                    trust_remote_code=True,
-                )
+                if "aria" not in self.api_endpoint_ids:
+                    self.api_endpoint_ids["aria"] = os.environ.get("ARIA_ENDPOINT_ID")
                 self.model_store["Loaded"] = True
             case "Qwen2-Audio":
                 model_id_or_path = self.qwen_audio_model_id

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -118,30 +118,30 @@ class AudioVLM:
                 #     device_map="auto",
                 # )
                 self.model_store["Loaded"] = True
-            case "Molmo-7B-D-0924-4bit":
-                model_id_or_path = self.molmo_model_id
-                self.model_store["Processor"] = AutoProcessor.from_pretrained(
-                    model_id_or_path,
-                    trust_remote_code=True,
-                    torch_dtype=torch.bfloat16,
-                    device_map="auto",
-                )
-                arguments = {
-                    "device_map": "auto",
-                    "torch_dtype": "auto",
-                    "trust_remote_code": True,
-                }
-                quantization_config = BitsAndBytesConfig(
-                    load_in_4bit=True,
-                    bnb_4bit_quant_type="fp4",  # or nf4
-                    bnb_4bit_use_double_quant=False,
-                )
-                arguments["quantization_config"] = quantization_config
-                self.model_store["Model"] = AutoModelForCausalLM.from_pretrained(
-                    model_id_or_path,
-                    **arguments,
-                )
-                self.model_store["Loaded"] = True
+            # case "Molmo-7B-D-0924-4bit":
+            #     model_id_or_path = self.molmo_model_id
+            #     self.model_store["Processor"] = AutoProcessor.from_pretrained(
+            #         model_id_or_path,
+            #         trust_remote_code=True,
+            #         torch_dtype=torch.bfloat16,
+            #         device_map="auto",
+            #     )
+            #     arguments = {
+            #         "device_map": "auto",
+            #         "torch_dtype": "auto",
+            #         "trust_remote_code": True,
+            #     }
+            #     quantization_config = BitsAndBytesConfig(
+            #         load_in_4bit=True,
+            #         bnb_4bit_quant_type="fp4",  # or nf4
+            #         bnb_4bit_use_double_quant=False,
+            #     )
+            #     arguments["quantization_config"] = quantization_config
+            #     self.model_store["Model"] = AutoModelForCausalLM.from_pretrained(
+            #         model_id_or_path,
+            #         **arguments,
+            #     )
+            #     self.model_store["Loaded"] = True
             case "Aria":
                 model_id_or_path = self.aria_model_id
                 self.model_store["Processor"] = AutoProcessor.from_pretrained(

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -16,29 +16,6 @@ from pydantic_settings import BaseSettings
 
 from audiovlm_demo.core.utils import resolve_path
 
-_ResolvedPath = Annotated[Path, AfterValidator(resolve_path)]
-
-
-class Config(BaseSettings):
-    """
-    Class to store configuration for the demo.
-
-    Includes paths to downloaded models, among other thnigs.
-    """
-
-    model_path: _ResolvedPath
-    aria_model_path: _ResolvedPath
-    qwen_audio_model_path: _ResolvedPath
-
-    @classmethod
-    def from_file(cls, path: str | Path) -> Config:
-        path = resolve_path(path)
-        if not path.is_file():
-            raise FileNotFoundError(f"{path} does not exist.")
-
-        with open(path) as file:
-            return cls.model_validate(tomlkit.load(file).unwrap())
-
 
 class AudioVLM:
     molmo_model_id: str = "allenai/Molmo-7B-D-0924"
@@ -50,8 +27,7 @@ class AudioVLM:
         "https://api.runpod.ai/v2/{endpoint_id}/status/{request_id}"
     )
 
-    def __init__(self, *, config: Config, model_store: dict | None = None):
-        self.config = config
+    def __init__(self, *, model_store: dict | None = None):
         model_store_keys = {"Loaded", "History", "Model", "Processor"}
         self.api_keys = {}
         self.api_endpoint_ids = {}

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -291,7 +291,7 @@ class AudioVLM:
         data = {
             "input": {
                 "image": image,
-                "text": messages,
+                "messages": messages,
             },
         }
 
@@ -300,7 +300,12 @@ class AudioVLM:
             "Authorization": f"Bearer {self.api_keys['runpod']}",
         }
 
-        return "Needs more reverb."
+        generated_text = self.send_receive_requests(
+            endpoint_id=self.api_endpoint_ids["aria"],
+            headers=headers,
+            data=data,
+        )
+        return generated_text
 
     # TODO: Add type annotations
     def qwen_callback(self, *, file_name, audio_file_content, chat_history):

--- a/audiovlm_demo/core/components.py
+++ b/audiovlm_demo/core/components.py
@@ -11,7 +11,6 @@ import httpx
 import torch
 
 
-
 class AudioVLM:
     molmo_model_id: str = "allenai/Molmo-7B-D-0924"
     aria_model_id: str = "rhymes-ai/Aria"

--- a/audiovlm_demo/main.py
+++ b/audiovlm_demo/main.py
@@ -1,14 +1,9 @@
-from audiovlm_demo import AudioVLM, AudioVLMPanel, Config
+from audiovlm_demo import AudioVLM, AudioVLMPanel
 
 
 def main():
-    config = Config(
-        model_path="allenai/Molmo-7B-D-0924",
-        aria_model_path="rhymes-ai/Aria",
-        qwen_audio_model_path="Qwen/Qwen2-Audio-7B-Instruct",
-    )
-    A = AudioVLM(config=config)
-    UI = AudioVLMPanel(engine=A)  # noqa: F841
+    A = AudioVLM()
+    UI = AudioVLMPanel(engine=A)
     return UI
 
 

--- a/audiovlm_demo/ui/main.html
+++ b/audiovlm_demo/ui/main.html
@@ -55,7 +55,7 @@
 
     <div class="model-box">
       <p><b>Molmo-7B-D-0924:</b> The smaller, but powerful, of the Molmo Vision-Language models - understands image contents and can 'point to' and count.</p>
-      <p><b>Molmo-7B-D-0924-4bit:</b> The same underlying model as above, but with quantized loading - meaning it will take up less VRAM, while performing similarly.</p>
+      <!-- <p><b>Molmo-7B-D-0924-4bit:</b> The same underlying model as above, but with quantized loading - meaning it will take up less VRAM, while performing similarly.</p> -->
       <p><b>Aria:</b> A 'Mixture of Experts' (MoE) Vision-Language Model that has many more total parameters than Molmo, yet half as many active at a given time. Faster, yet smarter.</p>
       <p><b>Qwen2-Audio-7B:</b> Qwen2-Audio is an Audio-Language Model, capable of understanding more than just words - it can discern speaker emotion as well as general sounds outside of language.</p>
     </div>

--- a/audiovlm_demo/ui/panel.py
+++ b/audiovlm_demo/ui/panel.py
@@ -31,7 +31,7 @@ class AudioVLMPanel:
             options=[
                 "Molmo-7B-D-0924",
                 # "Molmo-7B-D-0924-4bit",
-                # "Aria",
+                "Aria",
                 # "Qwen2-Audio",
             ],
             behavior="radio",

--- a/audiovlm_demo/ui/panel.py
+++ b/audiovlm_demo/ui/panel.py
@@ -32,7 +32,7 @@ class AudioVLMPanel:
                 "Molmo-7B-D-0924",
                 # "Molmo-7B-D-0924-4bit",
                 "Aria",
-                # "Qwen2-Audio",
+                "Qwen2-Audio",
             ],
             behavior="radio",
         )

--- a/audiovlm_demo/ui/panel.py
+++ b/audiovlm_demo/ui/panel.py
@@ -32,7 +32,7 @@ class AudioVLMPanel:
                 "Molmo-7B-D-0924",
                 # "Molmo-7B-D-0924-4bit",
                 "Aria",
-                "Qwen2-Audio",
+                # "Qwen2-Audio",
             ],
             behavior="radio",
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,6 @@ services:
       - "5006:5006"
     environment:
       - MOLMO_ENDPOINT_ID=${MOLMO_ENDPOINT_ID}
+      - ARIA_ENDPOINT_ID=${ARIA_ENDPOINT_ID}
+      - QWEN_ENDPOINT_ID=${QWEN_ENDPOINT_ID}
       - RUNPOD_API_KEY=${RUNPOD_API_KEY}


### PR DESCRIPTION
Changes code to call remote APIs on RunPod.io instead of downloading and calling models locally. 

There are still issues with Qwen2-Audio #32, but at least one of them is likely on the server side. 

The `Config` class is also [removed](https://github.com/Quansight/genai-demo-audio-vlm/pull/29/commits/5e2ae77eff08a22467527163ef3f34c35846759f) because it only held information about locally hosted models.